### PR TITLE
Removing unused environment variable

### DIFF
--- a/belt-node8-publish.gitlab-ci.yml
+++ b/belt-node8-publish.gitlab-ci.yml
@@ -3,7 +3,6 @@ image: node:8
 before_script:
   - echo "@cimpress-technology:registry=https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" > ~/.npmrc
   - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
-  - export VERSION=${CI_COMMIT_SHA:0:7}
 
 stages:
   - build


### PR DESCRIPTION
Removing environment variable VERSION which is both unused, and should not be used for its described intent, as we have other environment variables set more accurately for a package's version.

Dunno who else to add to this PR