### PR TITLE
Add gitlab ci configuration for node 10

### DIFF
--- a/belt-node10-publish.gitlab-ci.yml
+++ b/belt-node10-publish.gitlab-ci.yml
@@ -1,0 +1,47 @@
+image: node:10
+
+before_script:
+  - echo "@cimpress-technology:registry=https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" > ~/.npmrc
+  - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
+  - export VERSION=${CI_COMMIT_SHA:0:7}
+
+stages:
+  - build
+  - publish
+
+build:
+  stage: build
+  script:
+    - npm ci
+    - npm test
+  coverage: '/All files\s*\|\s*[.?\d]+\s*\|\s*([0-9.]+)/'
+  artifacts:
+    paths:
+      - coverage/
+
+dependency_scanning:
+  image: briangweber/docker-node:10
+  stage: build
+  allow_failure: true
+  services:
+    - docker:stable-dind
+  script:
+    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
+    - docker run
+        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
+        --volume "$PWD:/code"
+        --volume /var/run/docker.sock:/var/run/docker.sock
+        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
+  artifacts:
+    paths: [gl-dependency-scanning-report.json]
+
+publish:
+  stage: publish
+  script:
+    - npm config set @cimpress-technology:registry=https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/
+    - npm i @cimpress-technology/version-bumper -g
+    - bump-version
+    - add-keywords "${DEFAULT_KEYWORDS}"
+    - npm publish
+  only:
+    - master

--- a/belt-node10-service.gitlab-ci.yml
+++ b/belt-node10-service.gitlab-ci.yml
@@ -1,0 +1,71 @@
+image: node:10
+
+before_script:
+  - echo "@cimpress-technology:registry=https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" > ~/.npmrc
+  - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
+  - npm i -g grunt
+  - npm ci
+  - export VERSION=${CI_COMMIT_SHA:0:7}
+
+stages:
+  - build
+  - publish
+  - deploy
+
+build:
+  stage: build
+  script:
+    - npm test
+  coverage: '/All files\s*\|\s*[.?\d]+\s*\|\s*([0-9.]+)/'
+  artifacts:
+    paths:
+      - coverage/
+
+dependency_scanning:
+  image: briangweber/docker-node:10
+  stage: build
+  allow_failure: true
+  services:
+    - docker:stable-dind
+  script:
+    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
+    - docker run
+        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
+        --volume "$PWD:/code"
+        --volume /var/run/docker.sock:/var/run/docker.sock
+        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
+  artifacts:
+    paths: [gl-dependency-scanning-report.json]
+
+publish:
+  image: briangweber/docker-node:10
+  stage: publish
+  script:
+    - grunt bundle --packageVersion=$VERSION --packageName=$CI_PROJECT_NAME
+  only:
+    - master
+  except:
+    - schedules
+
+deploy-int:
+  stage: deploy
+  environment:
+    name: integration
+  script:
+    - grunt deploy --environment=int --packageVersion=$VERSION --packageName=$CI_PROJECT_NAME
+  only:
+    - master
+  except:
+    - schedules
+
+deploy-prd:
+  stage: deploy
+  environment:
+    name: production
+  script:
+    - grunt deploy --environment=prd --packageVersion=$VERSION --packageName=$CI_PROJECT_NAME
+  when: manual
+  only:
+    - master
+  except:
+    - schedules


### PR DESCRIPTION
* use `node:10` as base image instead of the custom one we had with `node:8` that upgraded npm itself. (npm 6.4.0 is now bundled with node 10)
* use `docker-node:10` instead of `docker-node:carbon`
* use `npm ci` instead of `npm install` in build job