### PR TITLE
Enable FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER feature flag

### DIFF
--- a/belt-node10-publish.gitlab-ci.yml
+++ b/belt-node10-publish.gitlab-ci.yml
@@ -23,6 +23,12 @@ dependency_scanning:
   image: briangweber/docker-node:10
   stage: build
   allow_failure: true
+  variables:
+    # NOTE: Breaking change introduced in v11.11 of the runner, using this
+    # feature flag makes newest versions behave like versions prior v11.11
+    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
+    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
+    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
     - docker:18-dind
   script:

--- a/belt-node10-service.gitlab-ci.yml
+++ b/belt-node10-service.gitlab-ci.yml
@@ -25,6 +25,12 @@ dependency_scanning:
   image: briangweber/docker-node:10
   stage: build
   allow_failure: true
+  variables:
+    # NOTE: Breaking change introduced in v11.11 of the runner, using this
+    # feature flag makes newest versions behave like versions prior v11.11
+    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
+    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
+    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
     - docker:18-dind
   script:

--- a/belt-node8-publish.gitlab-ci.yml
+++ b/belt-node8-publish.gitlab-ci.yml
@@ -23,6 +23,12 @@ dependency_scanning:
   image: briangweber/docker-node:latest
   stage: build
   allow_failure: true
+  variables:
+    # NOTE: Breaking change introduced in v11.11 of the runner, using this
+    # feature flag makes newest versions behave like versions prior v11.11
+    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
+    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
+    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
     - docker:18-dind
   script:

--- a/belt-node8-service.gitlab-ci.yml
+++ b/belt-node8-service.gitlab-ci.yml
@@ -25,6 +25,12 @@ dependency_scanning:
   image: briangweber/docker-node:carbon
   stage: build
   allow_failure: true
+  variables:
+    # NOTE: Breaking change introduced in v11.11 of the runner, using this
+    # feature flag makes newest versions behave like versions prior v11.11
+    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
+    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
+    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
     - docker:18-dind
   script:

--- a/java-service.gitlab-ci.yml
+++ b/java-service.gitlab-ci.yml
@@ -41,6 +41,12 @@ dependency_scanning:
   image: docker:stable
   stage: build
   allow_failure: true
+  variables:
+    # NOTE: Breaking change introduced in v11.11 of the runner, using this
+    # feature flag makes newest versions behave like versions prior v11.11
+    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
+    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
+    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
     - docker:18-dind
   before_script: []


### PR DESCRIPTION
From version 11.11+, gitlab-runner mounts volumes in a different order than before which makes the jobs using a recent runner version fail. (https://gitlab.com/gitlab-org/gitlab-runner/merge_requests/1352/diffs)

Because we share those configs and that FI's runner use v11.0.0, Orders and Belt runners use the v12.3.0, we need to turn on the feature flag `FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER` to make the dependency scanning job work again from recent runner versions.

A long term solution might consist of:

* working with FI/FUN to use our autoscaling runner terraform script to use a more recent version

* remove the usage the feature flag above and choose what docker in docker strategy to use across all jobs.

We should either use this approach https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker-workflow-with-docker-executor, which is what we do for the `dependency_scanning` job or this one https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-socket-binding which seems to be what we're doing with our `publish` job.

We are currently mixing both solutions.