### PR TITLE
Use fixed version of docker dind to avoid healthcheck error

### DIFF
--- a/base-ci-resource.yaml
+++ b/base-ci-resource.yaml
@@ -138,7 +138,7 @@ dependency_scanning:
     # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
     FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
-    - docker:18-dind
+    - docker:18.09.7-dind
   script:
     - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
     - docker run

--- a/belt-node10-publish.gitlab-ci.yml
+++ b/belt-node10-publish.gitlab-ci.yml
@@ -30,7 +30,7 @@ dependency_scanning:
     # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
     FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
-    - docker:18-dind
+    - docker:18.09.7-dind
   script:
     - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
     - docker run

--- a/belt-node10-service.gitlab-ci.yml
+++ b/belt-node10-service.gitlab-ci.yml
@@ -32,7 +32,7 @@ dependency_scanning:
     # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
     FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
-    - docker:18-dind
+    - docker:18.09.7-dind
   script:
     - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
     - docker run

--- a/belt-node8-publish.gitlab-ci.yml
+++ b/belt-node8-publish.gitlab-ci.yml
@@ -30,7 +30,7 @@ dependency_scanning:
     # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
     FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
-    - docker:18-dind
+    - docker:18.09.7-dind
   script:
     - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
     - docker run

--- a/belt-node8-service.gitlab-ci.yml
+++ b/belt-node8-service.gitlab-ci.yml
@@ -32,7 +32,7 @@ dependency_scanning:
     # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
     FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
-    - docker:18-dind
+    - docker:18.09.7-dind
   script:
     - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
     - docker run

--- a/java-service.gitlab-ci.yml
+++ b/java-service.gitlab-ci.yml
@@ -38,7 +38,7 @@ maven_build:
     paths: [target]
 
 dependency_scanning:
-  image: docker:stable
+  image: docker:18
   stage: build
   allow_failure: true
   variables:
@@ -48,12 +48,14 @@ dependency_scanning:
     # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
     FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
-    - docker:18-dind
+    - docker:18.09.7-dind
   before_script: []
   script:
     - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
     - docker run
         --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
+        --env MAVEN_OPTS="${MAVEN_OPTS}"
+        --env MAVEN_CLI_OPTS="${MAVEN_CLI_OPTS}"
         --volume "$PWD:/code"
         --volume /var/run/docker.sock:/var/run/docker.sock
         "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code


### PR DESCRIPTION
Looks like recent version of docker dind 18 changed and make the healhcheck fails sometimes, as suggested in the comment here https://gitlab.com/gitlab-org/gitlab-runner/issues/4260#note_194409033, fixing the version to `docker:18.09.7-dind` seems to be fine.

Additionally, I fixed the version of the docker image for the java project to the version 18 as we're running the version 18 in our deployments based on https://docs.aws.amazon.com/elasticbeanstalk/latest/relnotes/release-2019-06-17-linux.html#release-2019-06-17-linux.platforms.mcdocker (`docker:stable` use version 19).