### PR TITLE
Call Flyway with bash

### DIFF
--- a/base-ci-resource.yaml
+++ b/base-ci-resource.yaml
@@ -98,7 +98,7 @@ testNodeApplicationUsingPostgres:
       - $NODEPOSTGRESAPP == "true"
   script:
     - cp -r $CI_PROJECT_DIR/sql/* /flyway/sql/
-    - sh /flyway/flyway -url=jdbc:postgresql://$POSTGRES_SERVER:5432/$POSTGRES_DB -schemas=public -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD -placeholders.ENVIRONMENT=dev migrate
+    - bash /flyway/flyway -url=jdbc:postgresql://$POSTGRES_SERVER:5432/$POSTGRES_DB -schemas=public -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD -placeholders.ENVIRONMENT=dev migrate
     - $TYPESCRIPT == "true" && npm run build
     - npm test
   coverage: '/All files\s*\|\s*[.?\d]+\s*\|\s*([0-9.]+)/'

--- a/base-ci-resource.yaml
+++ b/base-ci-resource.yaml
@@ -16,7 +16,7 @@ stages:
   image: kevinrambaud/node-flyway:10-5.2.4-alpine
   script:
     - cp -r $CI_PROJECT_DIR/sql/* /flyway/sql/
-    - sh /flyway/flyway -url=jdbc:postgresql://$POSTGRES_SERVER:5432/$POSTGRES_DB -schemas=public -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD -placeholders.ENVIRONMENT=$CI_ENVIRONMENT_NAME migrate
+    - bash /flyway/flyway -url=jdbc:postgresql://$POSTGRES_SERVER:5432/$POSTGRES_DB -schemas=public -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD -placeholders.ENVIRONMENT=$CI_ENVIRONMENT_NAME migrate
 
 # base components of jobs that use node
 .node:


### PR DESCRIPTION
The migrate call is currently failing. Compared with [Supplier Inventory](https://opengrok.cimpress.io/source/xref/commerce/morch/supplier-inventory/.gitlab-ci.yml?r=a17a2c74#9), which calls `bash` instead of `sh`.