### PR TITLE
Make Maven dependency scans work (on new runner)

### DIFF
--- a/java-service.gitlab-ci.yml
+++ b/java-service.gitlab-ci.yml
@@ -49,18 +49,20 @@ dependency_scanning:
     FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
   services:
     - docker:18.09.7-dind
-  before_script: []
   script:
     - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
+    - cp ~/.m2/settings.xml .
     - docker run
         --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
         --env MAVEN_OPTS="${MAVEN_OPTS}"
-        --env MAVEN_CLI_OPTS="${MAVEN_CLI_OPTS}"
+        --env MAVEN_CLI_OPTS="--settings settings.xml -DskipTests ${MAVEN_CLI_OPTS}"
         --volume "$PWD:/code"
         --volume /var/run/docker.sock:/var/run/docker.sock
         "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
   artifacts:
     paths: [gl-dependency-scanning-report.json]
+  tags:
+    - dind
 
 push_bundle:
   image: cimpressorders/docker-node:12


### PR DESCRIPTION
[Here](https://gitlab.com/Cimpress-Technology/orders/order-processing/order-watchdog/-/jobs/561529465)'s an example of a working Maven dependency scan. To test, I copied this file to Order Watchdog's CI and then made the changes that I'm now making to this file.

[Here](https://gitlab.com/Cimpress-Technology/orders/infrastructure/gitlab-autoscaling-runner/-/merge_requests/9/diffs) is the MR to create the runner which will run jobs tagged with "dind". 