### PR TITLE
Use new dependency scanning method for java, nodejs and react projects

### DIFF
--- a/base-ci-resource.yaml
+++ b/base-ci-resource.yaml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 stages:
   - migrate-dev
   - build
@@ -57,7 +60,7 @@ maven-build:
   script:
     - 'mvn clean versions:set -DnewVersion=$PACKAGE_VERSION'
     - 'mvn $MAVEN_CLI_OPTS package'
-  except:  
+  except:
     refs:
       - schedules
   artifacts:
@@ -71,7 +74,7 @@ testNodeApplication:
   only:
     variables:
       - $NODEPOSTGRESAPP == null
-  except:  
+  except:
     refs:
       - schedules
     variables:
@@ -89,8 +92,8 @@ testNodeApplication:
 testNodeApplicationUsingPostgres:
   extends: .node
   image: cimpressorders/node-flyway:12-6.1.2-alpine
-  stage: build  
-  except:  
+  stage: build
+  except:
     refs:
       - schedules
   only:
@@ -134,30 +137,14 @@ analyze:
 
 # for node applications will scan your dependencies for issues at build time.
 dependency_scanning:
-  extends: .node
-  image: briangweber/docker-node:10
   stage: build
-  only:
-    variables:
-      - $PLATFORM == "node"
-  allow_failure: true
   variables:
-    # NOTE: Breaking change introduced in v11.11 of the runner, using this
-    # feature flag makes newest versions behave like versions prior v11.11
-    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
-    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
-    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
-  services:
-    - docker:18.09.7-dind
-  script:
-    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
-    - docker run
-        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
-        --volume "$PWD:/code"
-        --volume /var/run/docker.sock:/var/run/docker.sock
-        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
-  artifacts:
-    paths: [gl-dependency-scanning-report.json]
+    DS_JAVA_VERSION: 8
+  before_script:
+    - echo "@cimpress-technology:registry=https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" > ~/.npmrc
+    - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
+    - mkdir -p ~/.m2
+    - echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?><settings xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd\" xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><servers><server><username>${CT_ARTIFACTORY_USERNAME}</username><password>${CT_ARTIFACTORY_PASSWORD}</password><id>libs-release-local</id></server></servers></settings>" > ~/.m2/settings.xml
 
 #---Publish Jobs---
 
@@ -170,7 +157,7 @@ publish:
     - grunt bundle --packageVersion=$VERSION --packageName=$CI_PROJECT_NAME
   only:
     - master
-  except:  
+  except:
     refs:
       - schedules
 
@@ -183,7 +170,7 @@ migrate-postgres-dev:
   only:
     variables:
       - $DEV_POSTGRES_SERVER
-  except:  
+  except:
     refs:
       - schedules
   environment:
@@ -205,7 +192,7 @@ migrate-postgres-int:
       - master
     variables:
       - $INT_POSTGRES_SERVER
-  except:  
+  except:
     refs:
       - schedules
   environment:
@@ -220,8 +207,8 @@ migrate-postgres-int:
 # Deploys service to int autmatically after migrate-int stage completes sucessfully
 deploy-int:
   extends: .deploy
-  stage: deploy-int  
-  except:  
+  stage: deploy-int
+  except:
     refs:
       - schedules
   only:
@@ -238,8 +225,8 @@ deploy-prd-gate:
     name: prd
   allow_failure: false
   script:
-    - echo "beginning deployment"    
-  except:  
+    - echo "beginning deployment"
+  except:
     refs:
       - schedules
   only:
@@ -255,7 +242,7 @@ migrate-postgres-prd:
       - master
     variables:
       - $PRD_POSTGRES_SERVER
-  except:  
+  except:
     refs:
       - schedules
   environment:
@@ -274,7 +261,7 @@ deploy-prd:
   only:
     refs:
       - master
-  except:  
+  except:
     refs:
       - schedules
   environment:

--- a/belt-node10-publish.gitlab-ci.yml
+++ b/belt-node10-publish.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 image: node:10
 
 before_script:
@@ -20,26 +23,7 @@ build:
       - coverage/
 
 dependency_scanning:
-  image: briangweber/docker-node:10
   stage: build
-  allow_failure: true
-  variables:
-    # NOTE: Breaking change introduced in v11.11 of the runner, using this
-    # feature flag makes newest versions behave like versions prior v11.11
-    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
-    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
-    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
-  services:
-    - docker:18.09.7-dind
-  script:
-    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
-    - docker run
-        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
-        --volume "$PWD:/code"
-        --volume /var/run/docker.sock:/var/run/docker.sock
-        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
-  artifacts:
-    paths: [gl-dependency-scanning-report.json]
 
 publish:
   stage: publish

--- a/belt-node10-service.gitlab-ci.yml
+++ b/belt-node10-service.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 image: node:10
 
 before_script:
@@ -22,26 +25,10 @@ build:
       - coverage/
 
 dependency_scanning:
-  image: briangweber/docker-node:10
   stage: build
-  allow_failure: true
-  variables:
-    # NOTE: Breaking change introduced in v11.11 of the runner, using this
-    # feature flag makes newest versions behave like versions prior v11.11
-    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
-    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
-    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
-  services:
-    - docker:18.09.7-dind
-  script:
-    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
-    - docker run
-        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
-        --volume "$PWD:/code"
-        --volume /var/run/docker.sock:/var/run/docker.sock
-        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
-  artifacts:
-    paths: [gl-dependency-scanning-report.json]
+  before_script:
+    - echo "@cimpress-technology:registry=https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" > ~/.npmrc
+    - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
 
 publish:
   image: briangweber/docker-node:10

--- a/belt-node12-publish.gitlab-ci.yml
+++ b/belt-node12-publish.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 image: node:12
 
 before_script:
@@ -20,26 +23,7 @@ build:
       - coverage/
 
 dependency_scanning:
-  image: cimpressorders/docker-node:12
   stage: build
-  allow_failure: true
-  variables:
-    # NOTE: Breaking change introduced in v11.11 of the runner, using this
-    # feature flag makes newest versions behave like versions prior v11.11
-    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
-    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
-    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
-  services:
-    - docker:18.09.7-dind
-  script:
-    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
-    - docker run
-        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
-        --volume "$PWD:/code"
-        --volume /var/run/docker.sock:/var/run/docker.sock
-        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
-  artifacts:
-    paths: [gl-dependency-scanning-report.json]
 
 publish:
   stage: publish

--- a/belt-node12-service.gitlab-ci.yml
+++ b/belt-node12-service.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 image: node:12
 
 before_script:
@@ -22,26 +25,10 @@ build:
       - coverage/
 
 dependency_scanning:
-  image: cimpressorders/docker-node:12
   stage: build
-  allow_failure: true
-  variables:
-    # NOTE: Breaking change introduced in v11.11 of the runner, using this
-    # feature flag makes newest versions behave like versions prior v11.11
-    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
-    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
-    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
-  services:
-    - docker:18.09.7-dind
-  script:
-    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
-    - docker run
-        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
-        --volume "$PWD:/code"
-        --volume /var/run/docker.sock:/var/run/docker.sock
-        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
-  artifacts:
-    paths: [gl-dependency-scanning-report.json]
+  before_script:
+    - echo "@cimpress-technology:registry=https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" > ~/.npmrc
+    - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
 
 publish:
   image: cimpressorders/docker-node:12

--- a/belt-node8-publish.gitlab-ci.yml
+++ b/belt-node8-publish.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 image: node:8
 
 before_script:
@@ -20,26 +23,7 @@ build:
       - coverage/
 
 dependency_scanning:
-  image: briangweber/docker-node:latest
   stage: build
-  allow_failure: true
-  variables:
-    # NOTE: Breaking change introduced in v11.11 of the runner, using this
-    # feature flag makes newest versions behave like versions prior v11.11
-    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
-    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
-    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
-  services:
-    - docker:18.09.7-dind
-  script:
-    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
-    - docker run
-        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
-        --volume "$PWD:/code"
-        --volume /var/run/docker.sock:/var/run/docker.sock
-        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
-  artifacts:
-    paths: [gl-dependency-scanning-report.json]
 
 publish:
   stage: publish

--- a/belt-node8-service.gitlab-ci.yml
+++ b/belt-node8-service.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 image: briangweber/node:8
 
 before_script:
@@ -22,26 +25,10 @@ build:
       - coverage/
 
 dependency_scanning:
-  image: briangweber/docker-node:carbon
   stage: build
-  allow_failure: true
-  variables:
-    # NOTE: Breaking change introduced in v11.11 of the runner, using this
-    # feature flag makes newest versions behave like versions prior v11.11
-    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
-    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
-    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
-  services:
-    - docker:18.09.7-dind
-  script:
-    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
-    - docker run
-        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
-        --volume "$PWD:/code"
-        --volume /var/run/docker.sock:/var/run/docker.sock
-        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
-  artifacts:
-    paths: [gl-dependency-scanning-report.json]
+  before_script:
+    - echo "@cimpress-technology:registry=https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" > ~/.npmrc
+    - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
 
 publish:
   image: briangweber/docker-node:carbon

--- a/java-service.gitlab-ci.yml
+++ b/java-service.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 variables:
   # This will supress any download for dependencies and plugins or upload messages which would clutter the console log.
   # `showDateTime` will show the passed time in milliseconds. You need to specify `--batch-mode` to make this work.
@@ -22,6 +25,8 @@ stages:
   - deploy
 
 before_script:
+  - echo "@cimpress-technology:registry = https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" >> ~/.npmrc
+  - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
   - mkdir -p ~/.m2
   - echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?><settings xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd\" xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><servers><server><username>${CT_ARTIFACTORY_USERNAME}</username><password>${CT_ARTIFACTORY_PASSWORD}</password><id>libs-release-local</id></server></servers></settings>" > ~/.m2/settings.xml
   - export PACKAGE_VERSION=${CI_COMMIT_SHA:0:7}
@@ -38,31 +43,9 @@ maven_build:
     paths: [target]
 
 dependency_scanning:
-  image: docker:18
   stage: build
-  allow_failure: true
   variables:
-    # NOTE: Breaking change introduced in v11.11 of the runner, using this
-    # feature flag makes newest versions behave like versions prior v11.11
-    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4306#note_177127898
-    # Orders' runner use v12.3.0 whereas FI' runner use v11.0.0
-    FF_USE_LEGACY_VOLUMES_MOUNTING_ORDER: "true"
-  services:
-    - docker:18.09.7-dind
-  script:
-    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
-    - cp ~/.m2/settings.xml .
-    - docker run
-        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
-        --env MAVEN_OPTS="${MAVEN_OPTS}"
-        --env MAVEN_CLI_OPTS="--settings settings.xml -DskipTests ${MAVEN_CLI_OPTS}"
-        --volume "$PWD:/code"
-        --volume /var/run/docker.sock:/var/run/docker.sock
-        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
-  artifacts:
-    paths: [gl-dependency-scanning-report.json]
-  tags:
-    - dind
+    DS_JAVA_VERSION: 8
 
 push_bundle:
   image: cimpressorders/docker-node:12
@@ -73,8 +56,6 @@ push_bundle:
     - schedules
   dependencies: [maven_build]
   script:
-    - echo "@cimpress-technology:registry = https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" >> ~/.npmrc
-    - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
     - npm i -g grunt@1.1.0
     - npm ci
     - 'grunt bundle --packageVersion=$PACKAGE_VERSION --packageName=$CI_PROJECT_NAME'
@@ -86,8 +67,6 @@ push_bundle:
   except:
     - schedules
   script:
-    - echo "@cimpress-technology:registry = https://artifactory.cimpress.io/artifactory/api/npm/npm-release-local/" >> ~/.npmrc
-    - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> ~/.npmrc
     - npm i -g grunt@1.1.0
     - npm ci
     - 'grunt deploy --environment=$CI_ENVIRONMENT_NAME --packageVersion=$PACKAGE_VERSION --packageName=$CI_PROJECT_NAME'

--- a/react-spa-node-10.gitlab-ci.yml
+++ b/react-spa-node-10.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 variables:
   NODE_OPTIONS: "--max_old_space_size=4096"
   BUCKET_SUFFIX:
@@ -24,6 +27,11 @@ test:
   stage: test
   script:
     - npm run test
+
+dependency_scanning:
+  stage: test
+  before_script:
+    - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> .npmrc
 
 build-rev:
   <<: *node-common

--- a/react-spa.gitlab-ci.yml
+++ b/react-spa.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+
 variables:
   NODE_OPTIONS: "--max_old_space_size=4096"
   BUCKET_SUFFIX:
@@ -24,6 +27,11 @@ test:
   stage: test
   script:
     - npm run test
+
+dependency_scanning:
+  stage: test
+  before_script:
+    - echo "//artifactory.cimpress.io/artifactory/api/npm/npm-release-local/:_authToken=${CT_ARTIFACTORY_NPM_TOKEN}" >> .npmrc
 
 build-rev:
   <<: *node-common


### PR DESCRIPTION
As of Gitlab 13.4, the dependency scanning method we're using as been deprecated. The new way of doing it involve using the shared dependency-scanning template and customizing it based on our needs.

I validated the new method on 2 projects using the configs I updated: order-workflow-controller and order-operations-ui.

I still need to update the `base-ci-resource.yml` config to make it work with both node and java so we don't have to use the `only` syntax which has been deprecated in Gitlab 13.0.